### PR TITLE
fixed objective-c build includes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@
 #---------------------------------------------------
 project(
     'hatchet',
-    ['c', 'cpp', 'objcpp'],
+    ['c', 'cpp'],
     default_options : [
         'cpp_std=c++11',
         'warning_level=3',
@@ -25,19 +25,15 @@ project(
     license : 'GPLv3'
 )
 
-# add_languages('c')
-# add_languages('cpp')
-# add_languages('objcpp')
-
-
-#message ( build_machine.system() )
-message ( host_machine.system() )
-
+sys_name = host_machine.system().to_lower()
 
 # init compiler 
 #---------------------------------------------------
 cpp = meson.get_compiler('cpp')
-objcpp = meson.get_compiler('objcpp')
+
+if sys_name.contains('darwin')
+    objcpp = meson.get_compiler('objcpp')
+endif
 
 add_project_arguments(get_option('cxxflags'), language : 'cpp')
 add_project_link_arguments(get_option('ldflags'), language: 'cpp')

--- a/src/libhatchet/mac/meson.build
+++ b/src/libhatchet/mac/meson.build
@@ -5,7 +5,6 @@ libhatchet_inc += include_directories('.')
 libhatchet_mac_dir = meson.current_source_dir()
 
 
-if (sys_name.contains('darwin'))
-    libhatchet_src += files(
-        join_paths(libhatchet_mac_dir, 'FileHelpers.mm'))
-endif
+libhatchet_obj_src += files(
+    join_paths(libhatchet_mac_dir, 'FileHelpers.mm'))
+    

--- a/src/libhatchet/meson.build
+++ b/src/libhatchet/meson.build
@@ -77,13 +77,13 @@ libhatchet_gui_src = files(
     join_paths(libhatchet_dir, 'LatchManager.cpp'))
 
 
-libhatchet_h = files()
-
-
-libhatchet_moc_ui = files()
+libhatchet_obj_src = files()
 
 
 libhatchet_moc_src = files()
+
+
+libhatchet_h = files()
 
 
 libhatchet_moc_h = files(
@@ -118,6 +118,9 @@ libhatchet_moc_h = files(
     join_paths(libhatchet_dir, 'UrlHandler_p.h'),
     join_paths(libhatchet_dir, 'ViewManager.h'),
     join_paths(libhatchet_dir, 'ViewPagePlugin.h'))
+
+
+libhatchet_moc_ui = files()
 
 
 libhatchet_dirs = [
@@ -164,6 +167,10 @@ libhatchet_link_args = []
 
 if (get_option('with_gui'))
     libhatchet_src += libhatchet_gui_src
+endif
+
+if (sys_name.contains('darwin'))
+    libhatchet_src += libhatchet_obj_src
 endif
 
 

--- a/src/libhatchet/thirdparty/Qocoa/meson.build
+++ b/src/libhatchet/thirdparty/Qocoa/meson.build
@@ -22,8 +22,6 @@ libhatchet_moc_h += files(
     join_paths(libhatchet_thirdparty_qocoa_dir, 'qsearchfield.h'))
 
 
-if (sys_name.contains('darwin'))
-    libhatchet_src += files(
-        join_paths(libhatchet_thirdparty_qocoa_dir, 'qbutton_mac.mm'),
-        join_paths(libhatchet_thirdparty_qocoa_dir, 'qsearchfield_mac.mm'))
-endif
+libhatchet_obj_src += files(
+    join_paths(libhatchet_thirdparty_qocoa_dir, 'qbutton_mac.mm'),
+    join_paths(libhatchet_thirdparty_qocoa_dir, 'qsearchfield_mac.mm'))


### PR DESCRIPTION
Objective-C code was included in the build project. This allows the building of the project on systems where no Objective-C is present; unless the system is darwin based.