### PR TITLE
disabled pedantic errors by default

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -18,6 +18,7 @@ option(
     type : 'array',
     value : [
         '-Wdeprecated', 
+        '-Wno-pedantic',
         '-Wno-non-virtual-dtor',
         '-Wno-unused-parameter'],
     description : 'C build flags')


### PR DESCRIPTION
Pedantic errors are pretty spammy. This change disables them by default.